### PR TITLE
feat: add accessible help screen

### DIFF
--- a/chemfetch-mobile-live/app/index.tsx
+++ b/chemfetch-mobile-live/app/index.tsx
@@ -104,6 +104,10 @@ export default function HomeScreen() {
                 🔧 Network Diagnostics
               </ActionButton>
 
+              <ActionButton style="bg-blue-500" onPress={() => router.push('/help')}>
+                ❓ Help & Support
+              </ActionButton>
+
               <ActionButton
                 style="bg-white border border-border-color"
                 textColor="text-text-primary"

--- a/chemfetch-mobile-live/components/BottomBar.tsx
+++ b/chemfetch-mobile-live/components/BottomBar.tsx
@@ -59,6 +59,12 @@ export const BottomBar = () => {
           label="Register"
           isActive={pathname === '/register'}
         />
+        <TabButton
+          onPress={() => router.replace('/help')}
+          icon="❓"
+          label="Help"
+          isActive={pathname === '/help'}
+        />
         <TabButton onPress={handleLogout} icon="🚪" label="Sign Out" />
       </View>
     </SafeAreaView>


### PR DESCRIPTION
## Summary
- add Help tab to bottom navigation for quick access to help screen
- expose Help & Support button on home screen

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b180a66240832fb44f97895b21413b