### PR TITLE
Add scanned SDS parsing test

### DIFF
--- a/chemfetch-backend-live/ocr_service/sds_parser_new/sds_extractor.py
+++ b/chemfetch-backend-live/ocr_service/sds_parser_new/sds_extractor.py
@@ -230,8 +230,8 @@ def extract_after_label(section_text: str, labels):
             continue
 
         for label in labels:
-            # Case 1: label and value on same line
-            same = re.search(rf"{label}\s*[:\-]\s*(.+)", clean, re.IGNORECASE)
+            # Case 1: label and value on same line (colon/dash optional)
+            same = re.search(rf"^{label}\b\s*(?:[:\-]\s*)?(.+)", clean, re.IGNORECASE)
             if same:
                 value = same.group(1).strip()
                 # Truncate at appearance of other labels/contact keywords
@@ -398,8 +398,8 @@ def parse_pdf(path: Path) -> Dict[str, Any]:
     # Manufacturer
     manufacturer = extract_after_label(sec1, FIELD_LABELS['manufacturer'])
     if not manufacturer:
-        # Try alternative pattern
-        m = re.search(r'Details of the supplier[^\n]*\n([^\n]+)', sec1, re.IGNORECASE)
+        # Try alternative pattern grabbing first non-empty line after heading
+        m = re.search(r'Details of the supplier[^\n]*\n\s*([^\n]+)', sec1, re.IGNORECASE)
         if m:
             manufacturer = m.group(1).strip()
     result['manufacturer'] = {'value': manufacturer, 'confidence': 1.0 if manufacturer else 0.0}

--- a/chemfetch-backend-live/tests/test_scanned_sds.py
+++ b/chemfetch-backend-live/tests/test_scanned_sds.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import sys
+
+# Ensure project root is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ocr_service.sds_parser_new.sds_extractor import parse_pdf
+
+
+def test_scanned_sds_parsing():
+    pdf_path = Path("test-data/sds-pdfs/sds_4.pdf")
+    result = parse_pdf(pdf_path)
+
+    assert result["product_name"]["value"] == "Armor All Original Protectant - Spray"
+    assert result["manufacturer"]["value"] == "Energizer Manufacturing, Inc."
+    assert result["dangerous_goods_class"]["value"] == "Not subject to transport regulations: UN RTDG"
+    assert result["packing_group"]["value"] == "not assigned"
+    assert result["issue_date"]["value"] == "2011-09-03"


### PR DESCRIPTION
## Summary
- allow label extraction without delimiters and avoid mid-line matches
- improve manufacturer fallback parsing in SDS extractor
- test parsing of scanned SDS PDF for key fields

## Testing
- `pytest tests/test_scanned_sds.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f35515f8832fb6021497f551a21e