### PR TITLE
Fix manufacturer detection in SDS parser

### DIFF
--- a/chemfetch-backend-live/ocr_service/sds_parser_new/modules/config.py
+++ b/chemfetch-backend-live/ocr_service/sds_parser_new/modules/config.py
@@ -27,6 +27,7 @@ FIELD_LABELS = {
         r'Company\s+name\s+of\s+supplier',
         r'Producer',
         r'Company\s+name',
+        r'Registered\s+company\s+name',
         r'Distributor',
         r'Manufacturer\s*/\s*Supplier'
     ],

--- a/chemfetch-backend-live/ocr_service/sds_parser_new/modules/utils.py
+++ b/chemfetch-backend-live/ocr_service/sds_parser_new/modules/utils.py
@@ -31,7 +31,12 @@ def is_noise_text(text: str) -> bool:
         return True
     if text_clean.lower() in ['name', 'date', 'address', 'contact', 'details', 'information']:
         return True
-    
+    if text_clean.lower() in {
+        'australia', 'new zealand', 'united states', 'united kingdom',
+        'usa', 'uk', 'canada'
+    }:
+        return True
+
     return False
 
 


### PR DESCRIPTION
## Summary
- handle 'Registered company name' as manufacturer label
- ignore country-only values like 'AUSTRALIA' when parsing supplier fields
- fall back to next lines when same-line value is noise to better capture manufacturers

## Testing
- `pip install -r ocr_service/requirements.txt`
- `python test_sds.py`
- `python ocr_service/sds_parser_new/sds_extractor.py test-data/sds-pdfs/sds_1.PDF`

------
https://chatgpt.com/codex/tasks/task_e_68b39434d7d0832fa0bd6267a2d0b1ae